### PR TITLE
Added an explicit dependency on the generated C++ headers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ endif()
 
 add_executable(RosAria RosAria.cpp)
 add_dependencies(RosAria rosaria_gencfg)
+add_dependencies(RosAria rosaria_gencpp)
 
 target_link_libraries(RosAria ${catkin_LIBRARIES} ${Boost_LIBRARIES} Aria pthread dl rt)
 set_target_properties(RosAria PROPERTIES COMPILE_FLAGS "-fPIC")


### PR DESCRIPTION
The header BumperState.h was not being created, now it builds fine on Ubuntu 12.04 running Hydro.
