### PR TITLE
Dynamic reconfigure fix

### DIFF
--- a/RosAria.cpp
+++ b/RosAria.cpp
@@ -438,7 +438,7 @@ int RosAriaNode::Setup()
   dynConf_default.DriftFactor = DriftFactor;
   dynConf_default.RevCount    = RevCount;
   
-  dynamic_reconfigure_server->setConfigDefault(dynConf_max);
+  dynamic_reconfigure_server->setConfigDefault(dynConf_default);
   
   dynamic_reconfigure_server->setCallback(boost::bind(&RosAriaNode::dynamic_reconfigureCB, this, _1, _2));
 

--- a/RosAria.cpp
+++ b/RosAria.cpp
@@ -100,7 +100,7 @@ class RosAriaNode
     // Debug Aria
     bool debug_aria;
     std::string aria_log_filename;
-    
+
     // Robot Parameters
     int TicksMM, DriftFactor, RevCount;  // Odometry Calibration Settings
     
@@ -108,126 +108,117 @@ class RosAriaNode
     dynamic_reconfigure::Server<rosaria::RosAriaConfig> *dynamic_reconfigure_server;
 };
 
-void RosAriaNode::readParameters()
-{
-  // Robot Parameters  
-  robot->lock();
-  ros::NodeHandle n_("~");
-  if (n_.hasParam("TicksMM"))
-  {
-    n_.getParam( "TicksMM", TicksMM);
-    ROS_INFO("Setting TicksMM from ROS Parameter: %d", TicksMM);
-    robot->comInt(93, TicksMM);
-  }
-  else
-  {
-    TicksMM = robot->getOrigRobotConfig()->getTicksMM();
-    n_.setParam( "TicksMM", TicksMM);
-    ROS_INFO("Setting TicksMM from robot EEPROM: %d", TicksMM);
-  }
-  
-  if (n_.hasParam("DriftFactor"))
-  {
-    n_.getParam( "DriftFactor", DriftFactor);
-    ROS_INFO("Setting DriftFactor from ROS Parameter: %d", DriftFactor);
-    robot->comInt(89, DriftFactor);
-  }
-  else
-  {
-    DriftFactor = robot->getOrigRobotConfig()->getDriftFactor();
-    n_.setParam( "DriftFactor", DriftFactor);
-    ROS_INFO("Setting DriftFactor from robot EEPROM: %d", DriftFactor);
-  }
-  
-  if (n_.hasParam("RevCount"))
-  {
-    n_.getParam( "RevCount", RevCount);
-    ROS_INFO("Setting RevCount from ROS Parameter: %d", RevCount);
-    robot->comInt(88, RevCount);
-  }
-  else
-  {
-    RevCount = robot->getOrigRobotConfig()->getRevCount();
-    n_.setParam( "RevCount", RevCount);
-    ROS_INFO("Setting RevCount from robot EEPROM: %d", RevCount);
-  }
-  robot->unlock();
-}
-
 void RosAriaNode::dynamic_reconfigureCB(rosaria::RosAriaConfig &config, uint32_t level)
 {
-  //
-  // Odometry Settings
-  //
   robot->lock();
-  if(TicksMM != config.TicksMM and config.TicksMM > 0)
-  {
-    ROS_INFO("Setting TicksMM from Dynamic Reconfigure: %d -> %d ", TicksMM, config.TicksMM);
-    TicksMM = config.TicksMM;
-    robot->comInt(93, TicksMM);
-  }
+  if (level == ~0)
+    {//first run. check for 0 values == use robot defaults
+      if (config.TicksMM == 0)
+	config.TicksMM = robot->getOrigRobotConfig()->getTicksMM();
+      TicksMM = config.TicksMM;
+
+      if (config.DriftFactor == 0)
+	config.DriftFactor = robot->getOrigRobotConfig()->getDriftFactor();
+      DriftFactor = config.DriftFactor;
+
+      if (config.RevCount == 0)
+	config.RevCount = robot->getOrigRobotConfig()->getRevCount();
+      RevCount = config.RevCount;
+
+      if (config.trans_accel == 0)
+	config.trans_accel = robot->getTransAccel() / 1000.0;
+
+      if (config.trans_decel == 0)
+	config.trans_decel = robot->getTransDecel() / 1000.0;
+
+      if (config.lat_accel == 0)
+	config.lat_accel = robot->getLatAccel() / 1000.0;
+
+      if (config.lat_decel == 0)
+	config.lat_decel = robot->getLatDecel() / 1000.0;
+
+      if (config.rot_accel == 0)
+	config.rot_accel = robot->getRotAccel() * M_PI/180;
+
+      if (config.rot_decel == 0)
+	config.rot_decel = robot->getRotDecel() * M_PI/180;
+    } 
+  else 
+    {//next runs
+
+      //
+      // Odometry Settings
+      //
   
-  if(DriftFactor != config.DriftFactor)
-  {
-    ROS_INFO("Setting DriftFactor from Dynamic Reconfigure: %d -> %d ", DriftFactor, config.DriftFactor);
-    DriftFactor = config.DriftFactor;
-    robot->comInt(89, DriftFactor);
-  }
+       if(config.TicksMM != TicksMM and config.TicksMM > 0)
+	{
+	  ROS_INFO("Setting TicksMM from Dynamic Reconfigure: %d -> %d ", TicksMM, config.TicksMM);
+	  robot->comInt(93, config.TicksMM);
+	  TicksMM = config.TicksMM;
+	}
+      
+      if(config.DriftFactor != DriftFactor)
+	{
+	  ROS_INFO("Setting DriftFactor from Dynamic Reconfigure: %d -> %d ", DriftFactor, config.DriftFactor);
+	  robot->comInt(89, config.DriftFactor);
+	  DriftFactor = config.DriftFactor;
+	}
   
-  if(RevCount != config.RevCount and config.RevCount > 0)
-  {
-    ROS_INFO("Setting RevCount from Dynamic Reconfigure: %d -> %d ", RevCount, config.RevCount);
-    RevCount = config.RevCount;
-    robot->comInt(88, RevCount);
-  }
+      if(config.RevCount != RevCount and config.RevCount > 0)
+	{
+	  ROS_INFO("Setting RevCount from Dynamic Reconfigure: %d -> %d ", RevCount, config.RevCount);
+	  robot->comInt(88, config.RevCount);
+	  RevCount = config.RevCount;
+	}
   
-  //
-  // Acceleration Parameters
-  //
-  int value;
-  value = config.trans_accel * 1000;
-  if(value != robot->getTransAccel() and value > 0)
-  {
-    ROS_INFO("Setting TransAccel from Dynamic Reconfigure: %d", value);
-    robot->setTransAccel(value);
-  }
+      //
+      // Acceleration Parameters
+      //
+      int value;
+      value = config.trans_accel * 1000;
+      if(value != robot->getTransAccel() and value > 0)
+	{
+	  ROS_INFO("Setting TransAccel from Dynamic Reconfigure: %d", value);
+	  robot->setTransAccel(value);
+	}
   
-  value = config.trans_decel * 1000;
-  if(value != robot->getTransDecel() and value > 0)
-  {
-    ROS_INFO("Setting TransDecel from Dynamic Reconfigure: %d", value);
-    robot->setTransDecel(value);
-  } 
+      value = config.trans_decel * 1000;
+      if(value != robot->getTransDecel() and value > 0)
+	{
+	  ROS_INFO("Setting TransDecel from Dynamic Reconfigure: %d", value);
+	  robot->setTransDecel(value);
+	} 
   
-  value = config.lat_accel * 1000;
-  if(value != robot->getLatAccel() and value > 0)
-  {
-    ROS_INFO("Setting LatAccel from Dynamic Reconfigure: %d", value);
-    if (robot->getAbsoluteMaxLatAccel() > 0 )
-      robot->setLatAccel(value);
-  }
+      value = config.lat_accel * 1000;
+      if(value != robot->getLatAccel() and value > 0)
+	{
+	  ROS_INFO("Setting LatAccel from Dynamic Reconfigure: %d", value);
+	  if (robot->getAbsoluteMaxLatAccel() > 0 )
+	    robot->setLatAccel(value);
+	}
   
-  value = config.lat_decel * 1000;
-  if(value != robot->getLatDecel() and value > 0)
-  {
-    ROS_INFO("Setting LatDecel from Dynamic Reconfigure: %d", value);
-    if (robot->getAbsoluteMaxLatDecel() > 0 )
-      robot->setLatDecel(value);
-  }
+      value = config.lat_decel * 1000;
+      if(value != robot->getLatDecel() and value > 0)
+	{
+	  ROS_INFO("Setting LatDecel from Dynamic Reconfigure: %d", value);
+	  if (robot->getAbsoluteMaxLatDecel() > 0 )
+	    robot->setLatDecel(value);
+	}
   
-  value = config.rot_accel * 180/M_PI;
-  if(value != robot->getRotAccel() and value > 0)
-  {
-    ROS_INFO("Setting RotAccel from Dynamic Reconfigure: %d", value);
-    robot->setRotAccel(value);
-  }
-  
-  value = config.rot_decel * 180/M_PI;
-  if(value != robot->getRotDecel() and value > 0)
-  {
-    ROS_INFO("Setting RotDecel from Dynamic Reconfigure: %d", value);
-    robot->setRotDecel(value);
-  } 
+      value = config.rot_accel * 180/M_PI;
+      if(value != robot->getRotAccel() and value > 0)
+	{
+	  ROS_INFO("Setting RotAccel from Dynamic Reconfigure: %d", value);
+	  robot->setRotAccel(value);
+	}
+      
+      value = config.rot_decel * 180/M_PI;
+      if(value != robot->getRotDecel() and value > 0)
+	{
+	  ROS_INFO("Setting RotDecel from Dynamic Reconfigure: %d", value);
+	  robot->setRotDecel(value);
+	}
+    }
   robot->unlock();
 }
 
@@ -384,31 +375,12 @@ int RosAriaNode::Setup()
     return 1;
   }
 
-  readParameters();
-
   // Start dynamic_reconfigure server
   dynamic_reconfigure_server = new dynamic_reconfigure::Server<rosaria::RosAriaConfig>;
   
-  // Setup Parameter Minimums
-  rosaria::RosAriaConfig dynConf_min;
-  dynConf_min.trans_accel = robot->getAbsoluteMaxTransAccel() / 1000;
-  dynConf_min.trans_decel = robot->getAbsoluteMaxTransDecel() / 1000;
-  // TODO: Fix rqt dynamic_reconfigure gui to handle empty intervals
-  // Until then, set unit length interval.
-  dynConf_min.lat_accel = ((robot->getAbsoluteMaxLatAccel() > 0.0) ? robot->getAbsoluteMaxLatAccel() : 0.1) / 1000;
-  dynConf_min.lat_decel = ((robot->getAbsoluteMaxLatDecel() > 0.0) ? robot->getAbsoluteMaxLatDecel() : 0.1) / 1000;
-  dynConf_min.rot_accel = robot->getAbsoluteMaxRotAccel() * M_PI/180;
-  dynConf_min.rot_decel = robot->getAbsoluteMaxRotDecel() * M_PI/180;
-  
-  // I'm setting these upper bounds relitivly arbitrarily, feel free to increase them.
-  dynConf_min.TicksMM     = 10;
-  dynConf_min.DriftFactor = -200;
-  dynConf_min.RevCount    = -32760;
-  
-  dynamic_reconfigure_server->setConfigMin(dynConf_min);
-  
-  
+  //set max values from robot max
   rosaria::RosAriaConfig dynConf_max;
+  dynamic_reconfigure_server->getConfigMax(dynConf_max);
   dynConf_max.trans_accel = robot->getAbsoluteMaxTransAccel() / 1000;
   dynConf_max.trans_decel = robot->getAbsoluteMaxTransDecel() / 1000;
   // TODO: Fix rqt dynamic_reconfigure gui to handle empty intervals
@@ -417,28 +389,7 @@ int RosAriaNode::Setup()
   dynConf_max.lat_decel = ((robot->getAbsoluteMaxLatDecel() > 0.0) ? robot->getAbsoluteMaxLatDecel() : 0.1) / 1000;
   dynConf_max.rot_accel = robot->getAbsoluteMaxRotAccel() * M_PI/180;
   dynConf_max.rot_decel = robot->getAbsoluteMaxRotDecel() * M_PI/180;
-  
-  // I'm setting these upper bounds relitivly arbitrarily, feel free to increase them.
-  dynConf_max.TicksMM     = 200;
-  dynConf_max.DriftFactor = 200;
-  dynConf_max.RevCount    = 32760;
-  
-  dynamic_reconfigure_server->setConfigMax(dynConf_max);
-  
-  
-  rosaria::RosAriaConfig dynConf_default;
-  dynConf_default.trans_accel = robot->getTransAccel() / 1000;
-  dynConf_default.trans_decel = robot->getTransDecel() / 1000;
-  dynConf_default.lat_accel   = robot->getLatAccel() / 1000;
-  dynConf_default.lat_decel   = robot->getLatDecel() / 1000;
-  dynConf_default.rot_accel   = robot->getRotAccel() * M_PI/180;
-  dynConf_default.rot_decel   = robot->getRotDecel() * M_PI/180;
-
-  dynConf_default.TicksMM     = TicksMM;
-  dynConf_default.DriftFactor = DriftFactor;
-  dynConf_default.RevCount    = RevCount;
-  
-  dynamic_reconfigure_server->setConfigDefault(dynConf_default);
+  dynamic_reconfigure_server->setConfigMax(dynConf_max);  
   
   dynamic_reconfigure_server->setCallback(boost::bind(&RosAriaNode::dynamic_reconfigureCB, this, _1, _2));
 

--- a/RosAria.cpp
+++ b/RosAria.cpp
@@ -125,6 +125,12 @@ void RosAriaNode::dynamic_reconfigureCB(rosaria::RosAriaConfig &config, uint32_t
     if (config.RevCount == 0)
       config.RevCount = RevCount;
     
+    if (config.trans_vel_max == 0)
+      config.trans_vel_max = robot->getTransVelMax() / 1000.0;
+
+    if (config.rot_vel_max == 0)
+      config.rot_vel_max = robot->getRotVelMax() / 1000.0;
+
     if (config.trans_accel == 0)
       config.trans_accel = robot->getTransAccel() / 1000.0;
 
@@ -148,7 +154,6 @@ void RosAriaNode::dynamic_reconfigureCB(rosaria::RosAriaConfig &config, uint32_t
   //
   // Odometry Settings
   //
-  
   if(config.TicksMM != TicksMM and config.TicksMM > 0)
   {
     ROS_INFO("Setting TicksMM from Dynamic Reconfigure: %d -> %d ", TicksMM, config.TicksMM);
@@ -169,11 +174,29 @@ void RosAriaNode::dynamic_reconfigureCB(rosaria::RosAriaConfig &config, uint32_t
     robot->comInt(88, config.RevCount);
     RevCount = config.RevCount;
   }
+
+  //
+  // Max velocity Parameters
+  int value;
+  value = config.trans_vel_max * 1000;
+  if(value != robot->getTransVelMax() and value > 0)
+  {
+    ROS_INFO("Setting TransVelMax/TransNegVelMax from Dynamic Reconfigure: %d", value);
+    robot->setTransVelMax(value);
+    robot->setTransNegVelMax(-value);
+  }
+
+  value = config.rot_vel_max * 1000;
+  if(value != robot->getRotVelMax() and value > 0)
+  {
+    ROS_INFO("Setting TransRotMax from Dynamic Reconfigure: %d", value);
+    robot->setRotVelMax(value);
+  }
   
   //
   // Acceleration Parameters
   //
-  int value;
+  
   value = config.trans_accel * 1000;
   if(value != robot->getTransAccel() and value > 0)
   {
@@ -379,6 +402,8 @@ int RosAriaNode::Setup()
   //set max values from robot max
   rosaria::RosAriaConfig dynConf_max;
   dynamic_reconfigure_server->getConfigMax(dynConf_max);
+  dynConf_max.trans_vel_max = robot->getAbsoluteMaxTransVel() / 1000;
+  dynConf_max.rot_vel_max = robot->getAbsoluteMaxRotVel() / 1000;
   dynConf_max.trans_accel = robot->getAbsoluteMaxTransAccel() / 1000;
   dynConf_max.trans_decel = robot->getAbsoluteMaxTransDecel() / 1000;
   // TODO: Fix rqt dynamic_reconfigure gui to handle empty intervals

--- a/RosAria.cpp
+++ b/RosAria.cpp
@@ -112,113 +112,113 @@ void RosAriaNode::dynamic_reconfigureCB(rosaria::RosAriaConfig &config, uint32_t
 {
   robot->lock();
   if (level == ~0)
-    {//first run. check for 0 values == use robot defaults
-      if (config.TicksMM == 0)
-	config.TicksMM = robot->getOrigRobotConfig()->getTicksMM();
-      TicksMM = config.TicksMM;
+  {//first run. check for 0 values == use robot defaults
+    if (config.TicksMM == 0)
+      config.TicksMM = robot->getOrigRobotConfig()->getTicksMM();
+    TicksMM = config.TicksMM;
+    
+    if (config.DriftFactor == 0)
+      config.DriftFactor = robot->getOrigRobotConfig()->getDriftFactor();
+    DriftFactor = config.DriftFactor;
+    
+    if (config.RevCount == 0)
+      config.RevCount = robot->getOrigRobotConfig()->getRevCount();
+    RevCount = config.RevCount;
+    
+    if (config.trans_accel == 0)
+      config.trans_accel = robot->getTransAccel() / 1000.0;
 
-      if (config.DriftFactor == 0)
-	config.DriftFactor = robot->getOrigRobotConfig()->getDriftFactor();
-      DriftFactor = config.DriftFactor;
-
-      if (config.RevCount == 0)
-	config.RevCount = robot->getOrigRobotConfig()->getRevCount();
-      RevCount = config.RevCount;
-
-      if (config.trans_accel == 0)
-	config.trans_accel = robot->getTransAccel() / 1000.0;
-
-      if (config.trans_decel == 0)
-	config.trans_decel = robot->getTransDecel() / 1000.0;
-
-      if (config.lat_accel == 0)
-	config.lat_accel = robot->getLatAccel() / 1000.0;
-
-      if (config.lat_decel == 0)
-	config.lat_decel = robot->getLatDecel() / 1000.0;
-
-      if (config.rot_accel == 0)
-	config.rot_accel = robot->getRotAccel() * M_PI/180;
-
-      if (config.rot_decel == 0)
-	config.rot_decel = robot->getRotDecel() * M_PI/180;
-    } 
+    if (config.trans_decel == 0)
+      config.trans_decel = robot->getTransDecel() / 1000.0;
+    
+    if (config.lat_accel == 0)
+      config.lat_accel = robot->getLatAccel() / 1000.0;
+    
+    if (config.lat_decel == 0)
+      config.lat_decel = robot->getLatDecel() / 1000.0;
+    
+    if (config.rot_accel == 0)
+      config.rot_accel = robot->getRotAccel() * M_PI/180;
+    
+    if (config.rot_decel == 0)
+      config.rot_decel = robot->getRotDecel() * M_PI/180;
+  } 
   else 
-    {//next runs
+  {//next runs
 
-      //
-      // Odometry Settings
-      //
-  
-       if(config.TicksMM != TicksMM and config.TicksMM > 0)
-	{
-	  ROS_INFO("Setting TicksMM from Dynamic Reconfigure: %d -> %d ", TicksMM, config.TicksMM);
-	  robot->comInt(93, config.TicksMM);
-	  TicksMM = config.TicksMM;
-	}
-      
-      if(config.DriftFactor != DriftFactor)
-	{
-	  ROS_INFO("Setting DriftFactor from Dynamic Reconfigure: %d -> %d ", DriftFactor, config.DriftFactor);
-	  robot->comInt(89, config.DriftFactor);
-	  DriftFactor = config.DriftFactor;
-	}
-  
-      if(config.RevCount != RevCount and config.RevCount > 0)
-	{
-	  ROS_INFO("Setting RevCount from Dynamic Reconfigure: %d -> %d ", RevCount, config.RevCount);
-	  robot->comInt(88, config.RevCount);
-	  RevCount = config.RevCount;
-	}
-  
-      //
-      // Acceleration Parameters
-      //
-      int value;
-      value = config.trans_accel * 1000;
-      if(value != robot->getTransAccel() and value > 0)
-	{
-	  ROS_INFO("Setting TransAccel from Dynamic Reconfigure: %d", value);
-	  robot->setTransAccel(value);
-	}
-  
-      value = config.trans_decel * 1000;
-      if(value != robot->getTransDecel() and value > 0)
-	{
-	  ROS_INFO("Setting TransDecel from Dynamic Reconfigure: %d", value);
-	  robot->setTransDecel(value);
-	} 
-  
-      value = config.lat_accel * 1000;
-      if(value != robot->getLatAccel() and value > 0)
-	{
-	  ROS_INFO("Setting LatAccel from Dynamic Reconfigure: %d", value);
-	  if (robot->getAbsoluteMaxLatAccel() > 0 )
-	    robot->setLatAccel(value);
-	}
-  
-      value = config.lat_decel * 1000;
-      if(value != robot->getLatDecel() and value > 0)
-	{
-	  ROS_INFO("Setting LatDecel from Dynamic Reconfigure: %d", value);
-	  if (robot->getAbsoluteMaxLatDecel() > 0 )
-	    robot->setLatDecel(value);
-	}
-  
-      value = config.rot_accel * 180/M_PI;
-      if(value != robot->getRotAccel() and value > 0)
-	{
-	  ROS_INFO("Setting RotAccel from Dynamic Reconfigure: %d", value);
-	  robot->setRotAccel(value);
-	}
-      
-      value = config.rot_decel * 180/M_PI;
-      if(value != robot->getRotDecel() and value > 0)
-	{
-	  ROS_INFO("Setting RotDecel from Dynamic Reconfigure: %d", value);
-	  robot->setRotDecel(value);
-	}
+    //
+    // Odometry Settings
+    //
+    
+    if(config.TicksMM != TicksMM and config.TicksMM > 0)
+    {
+      ROS_INFO("Setting TicksMM from Dynamic Reconfigure: %d -> %d ", TicksMM, config.TicksMM);
+      robot->comInt(93, config.TicksMM);
+      TicksMM = config.TicksMM;
     }
+      
+    if(config.DriftFactor != DriftFactor)
+    {
+      ROS_INFO("Setting DriftFactor from Dynamic Reconfigure: %d -> %d ", DriftFactor, config.DriftFactor);
+      robot->comInt(89, config.DriftFactor);
+      DriftFactor = config.DriftFactor;
+    }
+  
+    if(config.RevCount != RevCount and config.RevCount > 0)
+    {
+      ROS_INFO("Setting RevCount from Dynamic Reconfigure: %d -> %d ", RevCount, config.RevCount);
+      robot->comInt(88, config.RevCount);
+      RevCount = config.RevCount;
+    }
+  
+    //
+    // Acceleration Parameters
+    //
+    int value;
+    value = config.trans_accel * 1000;
+    if(value != robot->getTransAccel() and value > 0)
+    {
+      ROS_INFO("Setting TransAccel from Dynamic Reconfigure: %d", value);
+      robot->setTransAccel(value);
+    }
+  
+    value = config.trans_decel * 1000;
+    if(value != robot->getTransDecel() and value > 0)
+    {
+      ROS_INFO("Setting TransDecel from Dynamic Reconfigure: %d", value);
+      robot->setTransDecel(value);
+    } 
+  
+    value = config.lat_accel * 1000;
+    if(value != robot->getLatAccel() and value > 0)
+    {
+      ROS_INFO("Setting LatAccel from Dynamic Reconfigure: %d", value);
+      if (robot->getAbsoluteMaxLatAccel() > 0 )
+        robot->setLatAccel(value);
+    }
+  
+    value = config.lat_decel * 1000;
+    if(value != robot->getLatDecel() and value > 0)
+    {
+      ROS_INFO("Setting LatDecel from Dynamic Reconfigure: %d", value);
+      if (robot->getAbsoluteMaxLatDecel() > 0 )
+        robot->setLatDecel(value);
+    }
+  
+    value = config.rot_accel * 180/M_PI;
+    if(value != robot->getRotAccel() and value > 0)
+    {
+      ROS_INFO("Setting RotAccel from Dynamic Reconfigure: %d", value);
+      robot->setRotAccel(value);
+    }
+      
+    value = config.rot_decel * 180/M_PI;
+    if(value != robot->getRotDecel() and value > 0)
+    {
+      ROS_INFO("Setting RotDecel from Dynamic Reconfigure: %d", value);
+      robot->setRotDecel(value);
+    }
+  }
   robot->unlock();
 }
 

--- a/RosAria.cpp
+++ b/RosAria.cpp
@@ -113,17 +113,17 @@ void RosAriaNode::dynamic_reconfigureCB(rosaria::RosAriaConfig &config, uint32_t
   robot->lock();
   if (level == ~0)
   {//first run. check for 0 values == use robot defaults
+    TicksMM = robot->getOrigRobotConfig()->getTicksMM();
     if (config.TicksMM == 0)
-      config.TicksMM = robot->getOrigRobotConfig()->getTicksMM();
-    TicksMM = config.TicksMM;
+      config.TicksMM = TicksMM;
     
+    DriftFactor = robot->getOrigRobotConfig()->getDriftFactor();
     if (config.DriftFactor == 0)
-      config.DriftFactor = robot->getOrigRobotConfig()->getDriftFactor();
-    DriftFactor = config.DriftFactor;
+      config.DriftFactor = DriftFactor;
     
+    RevCount = robot->getOrigRobotConfig()->getRevCount();
     if (config.RevCount == 0)
-      config.RevCount = robot->getOrigRobotConfig()->getRevCount();
-    RevCount = config.RevCount;
+      config.RevCount = RevCount;
     
     if (config.trans_accel == 0)
       config.trans_accel = robot->getTransAccel() / 1000.0;
@@ -143,81 +143,79 @@ void RosAriaNode::dynamic_reconfigureCB(rosaria::RosAriaConfig &config, uint32_t
     if (config.rot_decel == 0)
       config.rot_decel = robot->getRotDecel() * M_PI/180;
   } 
-  else 
-  {//next runs
+  
 
-    //
-    // Odometry Settings
-    //
-    
-    if(config.TicksMM != TicksMM and config.TicksMM > 0)
-    {
-      ROS_INFO("Setting TicksMM from Dynamic Reconfigure: %d -> %d ", TicksMM, config.TicksMM);
-      robot->comInt(93, config.TicksMM);
-      TicksMM = config.TicksMM;
-    }
+  //
+  // Odometry Settings
+  //
+  
+  if(config.TicksMM != TicksMM and config.TicksMM > 0)
+  {
+    ROS_INFO("Setting TicksMM from Dynamic Reconfigure: %d -> %d ", TicksMM, config.TicksMM);
+    robot->comInt(93, config.TicksMM);
+    TicksMM = config.TicksMM;
+  }
       
-    if(config.DriftFactor != DriftFactor)
-    {
-      ROS_INFO("Setting DriftFactor from Dynamic Reconfigure: %d -> %d ", DriftFactor, config.DriftFactor);
-      robot->comInt(89, config.DriftFactor);
-      DriftFactor = config.DriftFactor;
-    }
+  if(config.DriftFactor != DriftFactor)
+  {
+    ROS_INFO("Setting DriftFactor from Dynamic Reconfigure: %d -> %d ", DriftFactor, config.DriftFactor);
+    robot->comInt(89, config.DriftFactor);
+    DriftFactor = config.DriftFactor;
+  }
   
-    if(config.RevCount != RevCount and config.RevCount > 0)
-    {
-      ROS_INFO("Setting RevCount from Dynamic Reconfigure: %d -> %d ", RevCount, config.RevCount);
-      robot->comInt(88, config.RevCount);
-      RevCount = config.RevCount;
-    }
+  if(config.RevCount != RevCount and config.RevCount > 0)
+  {
+    ROS_INFO("Setting RevCount from Dynamic Reconfigure: %d -> %d ", RevCount, config.RevCount);
+    robot->comInt(88, config.RevCount);
+    RevCount = config.RevCount;
+  }
   
-    //
-    // Acceleration Parameters
-    //
-    int value;
-    value = config.trans_accel * 1000;
-    if(value != robot->getTransAccel() and value > 0)
-    {
-      ROS_INFO("Setting TransAccel from Dynamic Reconfigure: %d", value);
-      robot->setTransAccel(value);
-    }
+  //
+  // Acceleration Parameters
+  //
+  int value;
+  value = config.trans_accel * 1000;
+  if(value != robot->getTransAccel() and value > 0)
+  {
+    ROS_INFO("Setting TransAccel from Dynamic Reconfigure: %d", value);
+    robot->setTransAccel(value);
+  }
   
-    value = config.trans_decel * 1000;
-    if(value != robot->getTransDecel() and value > 0)
-    {
-      ROS_INFO("Setting TransDecel from Dynamic Reconfigure: %d", value);
-      robot->setTransDecel(value);
-    } 
+  value = config.trans_decel * 1000;
+  if(value != robot->getTransDecel() and value > 0)
+  {
+    ROS_INFO("Setting TransDecel from Dynamic Reconfigure: %d", value);
+    robot->setTransDecel(value);
+  } 
   
-    value = config.lat_accel * 1000;
-    if(value != robot->getLatAccel() and value > 0)
-    {
-      ROS_INFO("Setting LatAccel from Dynamic Reconfigure: %d", value);
-      if (robot->getAbsoluteMaxLatAccel() > 0 )
-        robot->setLatAccel(value);
-    }
+  value = config.lat_accel * 1000;
+  if(value != robot->getLatAccel() and value > 0)
+  {
+    ROS_INFO("Setting LatAccel from Dynamic Reconfigure: %d", value);
+    if (robot->getAbsoluteMaxLatAccel() > 0 )
+      robot->setLatAccel(value);
+  }
   
-    value = config.lat_decel * 1000;
-    if(value != robot->getLatDecel() and value > 0)
-    {
-      ROS_INFO("Setting LatDecel from Dynamic Reconfigure: %d", value);
-      if (robot->getAbsoluteMaxLatDecel() > 0 )
-        robot->setLatDecel(value);
-    }
+  value = config.lat_decel * 1000;
+  if(value != robot->getLatDecel() and value > 0)
+  {
+    ROS_INFO("Setting LatDecel from Dynamic Reconfigure: %d", value);
+    if (robot->getAbsoluteMaxLatDecel() > 0 )
+      robot->setLatDecel(value);
+  }
   
-    value = config.rot_accel * 180/M_PI;
-    if(value != robot->getRotAccel() and value > 0)
-    {
-      ROS_INFO("Setting RotAccel from Dynamic Reconfigure: %d", value);
-      robot->setRotAccel(value);
-    }
+  value = config.rot_accel * 180/M_PI;
+  if(value != robot->getRotAccel() and value > 0)
+  {
+    ROS_INFO("Setting RotAccel from Dynamic Reconfigure: %d", value);
+    robot->setRotAccel(value);
+  }
       
-    value = config.rot_decel * 180/M_PI;
-    if(value != robot->getRotDecel() and value > 0)
-    {
-      ROS_INFO("Setting RotDecel from Dynamic Reconfigure: %d", value);
-      robot->setRotDecel(value);
-    }
+  value = config.rot_decel * 180/M_PI;
+  if(value != robot->getRotDecel() and value > 0)
+  {
+    ROS_INFO("Setting RotDecel from Dynamic Reconfigure: %d", value);
+    robot->setRotDecel(value);
   }
   robot->unlock();
 }

--- a/cfg/RosAria.cfg
+++ b/cfg/RosAria.cfg
@@ -7,12 +7,14 @@ gen = ParameterGenerator()
 
 #Default values set to 0 will be set from robot defaults
 
-gen.add("trans_accel", double_t, 0, "Translational acceleration (m/s^2)", 0, 0 ) #max from robot config
-gen.add("trans_decel", double_t, 0, "Translational deceleration (m/s^2)", 0, 0 ) #max from robot config
-gen.add("lat_accel"  , double_t, 0, "Lateral acceleration (m/s^2)"      , 0, 0 ) #max from robot config
-gen.add("lat_decel"  , double_t, 0, "Lateral deceleration (m/s^2)"      , 0, 0 ) #max from robot config
-gen.add("rot_accel"  , double_t, 0, "Rotational acceleration (rad/s^2)" , 0, 0 ) #max from robot config
-gen.add("rot_decel"  , double_t, 0, "Rotational deceleration (rad/s^2)" , 0, 0 ) #max from robot config
+gen.add("trans_vel_max", double_t, 0, "Max translational velocity (m/s)"  , 0, 0 ) #max from robot config
+gen.add("rot_vel_max"  , double_t, 0, "Max rotational velocity (rad/s)"   , 0, 0 ) #max from robot config
+gen.add("trans_accel"  , double_t, 0, "Translational acceleration (m/s^2)", 0, 0 ) #max from robot config
+gen.add("trans_decel"  , double_t, 0, "Translational deceleration (m/s^2)", 0, 0 ) #max from robot config
+gen.add("lat_accel"    , double_t, 0, "Lateral acceleration (m/s^2)"      , 0, 0 ) #max from robot config
+gen.add("lat_decel"    , double_t, 0, "Lateral deceleration (m/s^2)"      , 0, 0 ) #max from robot config
+gen.add("rot_accel"    , double_t, 0, "Rotational acceleration (rad/s^2)" , 0, 0 ) #max from robot config
+gen.add("rot_decel"    , double_t, 0, "Rotational deceleration (rad/s^2)" , 0, 0 ) #max from robot config
 
 #bounds are relitivly arbitrarily, feel free to increase them.
 gen.add("TicksMM"    , int_t, 0, "Encoder ticks/mm"                            , 0, 0, 256)

--- a/cfg/RosAria.cfg
+++ b/cfg/RosAria.cfg
@@ -5,22 +5,21 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
+#Default values set to 0 will be set from robot defaults
 
-gen.add("trans_accel", double_t, 0, "Translational acceleration (m/s^2)")
-gen.add("trans_decel", double_t, 0, "Translational deceleration (m/s^2)" )
-gen.add("lat_accel"  , double_t, 0, "Lateral acceleration (m/s^2)"      )
-gen.add("lat_decel"  , double_t, 0, "Lateral deceleration (m/s^2)"      )
-gen.add("rot_accel"  , double_t, 0, "Rotational acceleration (rad/s^2)" )
-gen.add("rot_decel"  , double_t, 0, "Rotational deceleration (rad/s^2)" )
+gen.add("trans_accel", double_t, 0, "Translational acceleration (m/s^2)", 0, 0 ) #max from robot config
+gen.add("trans_decel", double_t, 0, "Translational deceleration (m/s^2)", 0, 0 ) #max from robot config
+gen.add("lat_accel"  , double_t, 0, "Lateral acceleration (m/s^2)"      , 0, 0 ) #max from robot config
+gen.add("lat_decel"  , double_t, 0, "Lateral deceleration (m/s^2)"      , 0, 0 ) #max from robot config
+gen.add("rot_accel"  , double_t, 0, "Rotational acceleration (rad/s^2)" , 0, 0 ) #max from robot config
+gen.add("rot_decel"  , double_t, 0, "Rotational deceleration (rad/s^2)" , 0, 0 ) #max from robot config
 
-
-# Default values are from the Pioneer Manual p.53
-
-gen.add("TicksMM"    , int_t, 0, "Encoder ticks/mm"                            )
+#bounds are relitivly arbitrarily, feel free to increase them.
+gen.add("TicksMM"    , int_t, 0, "Encoder ticks/mm"                            , 0, 0, 256)
 gen.add("DriftFactor", int_t, 0, "Value in 1/8192 increments to be added or " + 
                                  "subtracted from the left encoder ticks in " +
-                                 "order to compensate for tire differences."   )
+                                 "order to compensate for tire differences."   , 0, -200, 200)
 gen.add("RevCount"   , int_t, 0, "The number of differential encoder ticks " + 
-                                 "for a 180-degree revolution of the robot."   )
+                                 "for a 180-degree revolution of the robot."   , 0, 0, 32760)
 
 exit(gen.generate(PACKAGE, "RosAria", "RosAria"))


### PR DESCRIPTION
I've work around the dynamic_reconfigure functionality implemented in rosaria, that I think it wasn't working well.
I've added defaults, minimums and maximums (if known) to the cfg file. If default value is 0 the parameter is set from robot defaults or from parameter server if said parameter is set.

Now rqt_reconfigure starts with the current parameters.

Also, I've added [trans|rot]_vel_max parameters.

The code compiles and I've tested it on my robot. Feel free to verify it before merging it.
