### PR TITLE
Added ${ROOT} variable in CMakelists.txt to fix if statment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ find_package(Boost REQUIRED COMPONENTS thread)
 include_directories(${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} )
 
 # The installation package provided by Adept doesn't follow Debian policies
-if(EXISTS "/usr/local/Aria/include/Aria.h")
+if(EXISTS "${ROOT}/usr/local/Aria/include/Aria.h")
   add_definitions(-DADEPT_PKG)
   include_directories( /usr/local/Aria/include)
   link_directories(/usr/local/Aria/lib)


### PR DESCRIPTION
Catkin couldnt find the header even though it was there.  Adding the variable fixed it.
